### PR TITLE
Include missing babel-core package in client package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "redux": "^3.3.1"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
App client can't be properly built because package `babel-core` is missing from `package.json`. This PR includes `babel-core` at its last version.